### PR TITLE
Fix the broken github link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ social:
   meetup:         http://www.meetup.com/RubySlovenia/
   twitter:        https://www.twitter.com/RubySlovenia/
   facebook:       https://www.facebook.com/groups/RubySlovenia/
-  github:         https://github.com/SloveniaRUG
+  github:         https://github.com/RubySlovenia
   slack:          http://slack.rug.si/
 
 email: info@rug.si


### PR DESCRIPTION
I guess the organization name was changed on github so the link was broken.